### PR TITLE
Fix "literal render"

### DIFF
--- a/src/repl_tooling/editor_helpers.cljs
+++ b/src/repl_tooling/editor_helpers.cljs
@@ -62,9 +62,13 @@
       (symbol res))))
 
 (defn parse-result [result]
-  (if (:result result)
-    (update result :result read-result)
-    (update result :error read-result)))
+  (let [read #(if (:parsed? result)
+                %
+                (cond-> (read-result %) (:literal result) LiteralRender.))]
+    (assoc (if (:result result)
+             (update result :result read)
+             (update result :error read))
+           :parsed? true)))
 
 (defn strip-comments [text]
   (-> text

--- a/src/repl_tooling/features/autocomplete.cljs
+++ b/src/repl_tooling/features/autocomplete.cljs
@@ -45,7 +45,7 @@
                                                   {:tag-candidates true
                                                    :ns '~ns
                                                    :context ~context})]
-                   (clojure.core/symbol (clojure.core/pr-str (clojure.core/vec completions#)))))]
+                   (clojure.core/vec completions#)))]
     (js/Promise. (fn [resolve]
                    (eval/evaluate repl code {:ignore true} #(if-let [res (:result %)]
                                                               (resolve (helpers/read-result res))

--- a/src/repl_tooling/features/documentation.cljs
+++ b/src/repl_tooling/features/documentation.cljs
@@ -1,14 +1,15 @@
-(ns repl-tooling.features.documentation
-  (:require [clojure-plus.repl :as repl]
-            [repl-tooling.editor-helpers :as editor-helpers]))
-
-(defn doc-for [editor row var-name]
-  (let [ns-name (repl/ns-for editor)
-        var-name (symbol (str "#'" var-name))
-        code `(clojure.core/let [m# (clojure.core/meta ~var-name)]
-                (new editor-helpers/LiteralRenderResult
-                 (clojure.core/str "-------------------------\n"
-                                   (:ns m#) "/" (:name m#) "\n"
-                                   (:arglists m#) "\n  "
-                                   (:doc m#))))]
-    (repl/eval-and-present editor ns-name (.getFileName editor) row 0 code)))
+(ns repl-tooling.features.documentation)
+;   (:require [clojure-plus.repl :as repl]
+;             [repl-tooling.editor-helpers :as editor-helpers]))
+;
+; (defn doc-for [ns-name  var-name]
+;   (let [var-name (symbol (str "#'" var-name))
+;         code `(clojure.core/let [m# (clojure.core/meta ~var-name)]
+;                 (new editor-helpers/LiteralRenderResult
+;                  (clojure.core/str "-------------------------\n"
+;                                    (:ns m#) "/" (:name m#) "\n"
+;                                    (:arglists m#) "\n  "
+;                                    (:doc m#))))]
+;
+;     (repl/eval-and-present editor ns-name (.getFileName editor) row 0 code)))
+;

--- a/src/repl_tooling/repl_client/clojure.cljs
+++ b/src/repl_tooling/repl_client/clojure.cljs
@@ -209,7 +209,8 @@
                     "['" id " :error (cljs.core/pr-str {:obj (cljs.core/pr-str e) :type (.-type e) "
                     ":message (.-message e) :trace (.-stack e)})])))\n")]
 
-      (swap! pending assoc id {:callback callback :ignore (:ignore opts)})
+      (swap! pending assoc id {:callback callback :ignore (:ignore opts)
+                               :pass (:pass opts)})
 
       (when-let [ns-name (:namespace opts)]
         (async/put! in (str "(ns " ns-name ")")))
@@ -229,7 +230,7 @@
                                   reader/read-string
                                   (reader/read-string {:default default-tags}))]
           (reset! buffer nil)
-          ((:callback pendency) {key parsed})
+          ((:callback pendency) (assoc (:pass pendency) key parsed))
           (swap! pending dissoc id)
           (when-not (:ignore pendency) (output-fn {:as-text out :result parsed})))
         (swap! buffer str out))

--- a/test/repl_tooling/repl_client/clojure_test.cljs
+++ b/test/repl_tooling/repl_client/clojure_test.cljs
@@ -22,6 +22,12 @@
       (check (await! out) =includes=> {:result "nil"})
       (check (await! out) => {:result "nil" :as-text "nil"}))
 
+    (testing "passing args to result"
+      (let [res (async/promise-chan)]
+        (eval/evaluate repl "(+ 2 3)" {:pass {:literal true}} #(some->> % (async/put! res)))
+        (check (await! res) =includes=> {:result "5" :literal true}))
+      (check (await! out) =includes=> {:result "5" :literal true}))
+
     (testing "passing parameters to evaluation"
       ; FIXME: We need better integration when we stack commands
       (await! (async/timeout 200))


### PR DESCRIPTION
Literal render was not working properly. This PR fixes it, and allows a new key to be passed to `evaluate` - `:pass` - that will pass-through information to results.

This means that we can now pass information that allows us to decide, on callback, how results would be rendered.