### PR TITLE
Fix issues with DOC

### DIFF
--- a/src/repl_tooling/editor_helpers.cljs
+++ b/src/repl_tooling/editor_helpers.cljs
@@ -62,13 +62,13 @@
       (symbol res))))
 
 (defn parse-result [result]
-  (let [read #(if (:parsed? result)
-                %
-                (cond-> (read-result %) (:literal result) LiteralRender.))]
-    (assoc (if (:result result)
-             (update result :result read)
-             (update result :error read))
-           :parsed? true)))
+  (assoc (if (:result result)
+           (update result :result #(if (:parsed? result)
+                                     %
+                                     (cond-> (read-result %)
+                                             (:literal result) LiteralRender.)))
+           (update result :error #(cond-> % (not (:parsed? result)) read-result)))
+         :parsed? true))
 
 (defn strip-comments [text]
   (-> text

--- a/src/repl_tooling/repl_client/clojure.cljs
+++ b/src/repl_tooling/repl_client/clojure.cljs
@@ -213,7 +213,7 @@
                                :pass (:pass opts)})
 
       (when-let [ns-name (:namespace opts)]
-        (async/put! in (str "(ns " ns-name ")")))
+        (async/put! in (str "(in-ns '" ns-name ")")))
 
       (async/put! in code)
       (swap! (:session evaluator) assoc :pending [])


### PR DESCRIPTION
Basically, CLJS was not firing errors when finding documentation for var, nor it was resolving correctly namespaces.