### PR TITLE
Handle multiple forms in evaluate-code

### DIFF
--- a/src/repl_tooling/repl_client/clojurescript.cljs
+++ b/src/repl_tooling/repl_client/clojurescript.cljs
@@ -9,8 +9,8 @@
 
 (defn evaluate-code [in pending command opts callback]
   (let [id (gensym)
-        code (str "(cljs.core/pr-str (try (clojure.core/let [res\n" command
-                  "\n] ['" id " :result (cljs.core/pr-str res)]) (catch :default e "
+        code (str "(cljs.core/pr-str (try (clojure.core/let [res\n(do\n" command
+                  "\n)] ['" id " :result (cljs.core/pr-str res)]) (catch :default e "
                   "['" id " :error (cljs.core/pr-str {:obj (cljs.core/pr-str e) :type (.-type e) "
                   ":message (.-message e) :trace (.-stack e)})])))\n")]
     (swap! pending assoc id {:callback callback :ignore (:ignore opts)})


### PR DESCRIPTION
The evaluate selection command for ClojureScript leads to execution of evaluate-code, but the latter appears to assume a string containing a single 'top-level' form.  When the string contains more than one 'top-level' form (e.g. (+ 1 1) (- 43 1) vs a single (+ 1 1)), evaluation errors result.

Wrapping the string in a do block appears to address the issue.

Roughly:

```clojure
(let [res 
       command
      ]
  ;;
  )
```

vs:

```clojure
(let [res (do
       command
      )]
  ;;
  )
