### PR TITLE
Fixed var definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "showdown": "^1.9.0"
   },
   "devDependencies": {
-    "shadow-cljs": "^2.8.31"
+    "shadow-cljs": "^2.8.37"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -5,7 +5,6 @@
                 [check "0.0.3-SNAPSHOT"]
                 [reagent "0.8.1"]
                 [devcards "0.2.5"]
-                [nubank/matcher-combinators "0.9.0"]
                 [org.clojure/tools.reader "1.3.2"]]
 
  :builds {:integration {:target :browser

--- a/src/repl_tooling/features/definition.cljs
+++ b/src/repl_tooling/features/definition.cljs
@@ -6,9 +6,10 @@
 (defn- cmd-for-filename [the-var]
   `(~'clojure.core/let [res# (~'clojure.core/meta (~'clojure.core/resolve (quote ~the-var)))]
      (~'clojure.core/require 'clojure.java.io)
-     [(~'clojure.core/some->> (:file res#)
-                              (.getResource (~'clojure.lang.RT/baseLoader))
-                              .getPath)
+     [(~'clojure.core/or (~'clojure.core/some->> res# :file
+                           (.getResource (~'clojure.lang.RT/baseLoader))
+                           .getPath)
+                         (:file res#))
       (:line res#)]))
 
 (defn- cmd-for-read-jar [jar-file-name]

--- a/src/repl_tooling/features/definition.cljs
+++ b/src/repl_tooling/features/definition.cljs
@@ -21,20 +21,18 @@
      (java.lang.String. (.toByteArray ba#))))
 
 (defn- get-result [repl [file-name line] resolve]
-  (if (nil? file-name)
-    (resolve nil)
+  (if (string? file-name)
     (let [chan (async/promise-chan)]
-      (async/go
-       (if (re-find #"\.jar!/" file-name)
-         (let [cmd (cmd-for-read-jar file-name)]
-           (eval/evaluate repl cmd {:ignore true} #(->> %
-                                                        editor-helpers/parse-result
-                                                        :result
-                                                        (async/put! chan)))
-           (resolve {:file-name file-name
-                     :line (dec line)
-                     :contents (async/<! chan)}))
-         (resolve {:file-name file-name :line (dec line)}))))))
+      (if (re-find #"\.jar!/" file-name)
+        (let [cmd (cmd-for-read-jar file-name)]
+          (eval/evaluate repl cmd {:ignore true}
+                         #(let [contents (->> % editor-helpers/parse-result :result)]
+                            (resolve {:file-name file-name
+                                      :line (dec line)
+                                      :contents contents}))))
+        (resolve {:file-name file-name :line (dec line)})))
+    (resolve nil)))
+
 
 (defn find-var-definition [repl ns-name symbol-name]
   (js/Promise.

--- a/test/repl_tooling/features/definition_child.clj
+++ b/test/repl_tooling/features/definition_child.clj
@@ -1,0 +1,8 @@
+(ns repl-tooling.features.definition-child)
+
+(defn some-function []
+  "I do nothin'...")
+
+(def some-var "I'm also nothing...")
+
+(def other-var "I'll be inlined")

--- a/test/repl_tooling/features/definition_helper.clj
+++ b/test/repl_tooling/features/definition_helper.clj
@@ -1,0 +1,5 @@
+(ns repl-tooling.features.definition-helper
+  (:require [repl-tooling.features.definition-child :as c :refer [other-var]]))
+
+(defn some-function []
+  (str "Just a function " other-var))

--- a/test/repl_tooling/features/definition_test.cljs
+++ b/test/repl_tooling/features/definition_test.cljs
@@ -1,0 +1,60 @@
+(ns repl-tooling.features.definition-test
+  (:require [clojure.test :refer-macros [testing async is]]
+            [devcards.core :as cards :include-macros true]
+            [check.core :refer-macros [check]]
+            [clojure.core.async :as async :include-macros true]
+            [repl-tooling.repl-client :as client]
+            [repl-tooling.eval :as eval]
+            [repl-tooling.repl-client.clojure :as clj]
+            [repl-tooling.features.definition :as def])
+  (:require-macros [repl-tooling.eval-helpers :refer [eval-on-repl]]
+                   [repl-tooling.features.definition-helper :as h]))
+
+(set! cards/test-timeout 8000)
+(cards/deftest finding-definition
+  (async done
+    (client/disconnect! :definition-test1)
+    (async/go
+     (let [repl (clj/repl :definition-test1 "localhost" 2233 identity)
+           inside-jar (async/promise-chan)
+           in-other-ns (async/promise-chan)
+           in-other-by-refer (async/promise-chan)
+           in-same-ns (async/promise-chan)]
+       (eval-on-repl ":ok")
+       (-> repl :session deref :state
+           (clj/unrepl-cmd :print-limits
+                           {:unrepl.print/string-length 9223372036854775807
+                            :unrepl.print/coll-length 9223372036854775807
+                            :unrepl.print/nesting-depth 9223372036854775807})
+           eval-on-repl)
+
+       (testing "finds symbols inside jars, and get file's contents"
+         (. (def/find-var-definition repl 'user "prn") then #(async/put! inside-jar %))
+         (-> inside-jar async/<! :line (check => number?))
+         (-> inside-jar async/<! :file-name (check => string?))
+         (-> inside-jar async/<! :contents (check => string?)))
+
+       (testing "finds symbols inside other namespaces, and gets file"
+         (. (def/find-var-definition repl
+              'repl-tooling.features.definition-helper "c/some-function")
+           then #(async/put! in-other-ns %))
+         (-> in-other-ns async/<! :line (check => number?))
+         (-> in-other-ns async/<! :file-name
+             (check => #(re-find #"repl_tooling/features/definition_child\.clj" %)))
+
+         (. (def/find-var-definition repl
+              'repl-tooling.features.definition-helper "other-var")
+           then #(async/put! in-other-by-refer %))
+         (-> in-other-by-refer async/<! :file-name
+             (check => #(re-find #"repl_tooling/features/definition_child\.clj" %))))
+
+       (testing "finds symbols inside same namespace, and gets file"
+         (. (def/find-var-definition repl
+              'repl-tooling.features.definition-helper "some-function")
+           then #(async/put! in-same-ns %))
+         (-> in-same-ns async/<! :line (check => number?))
+         (-> in-same-ns async/<! :file-name
+             (check => #(re-find #"repl_tooling/features/definition_helper\.clj" %))))
+
+       (client/disconnect! :definition-test1)
+       (done)))))

--- a/test/repl_tooling/integration/ui.cljs
+++ b/test/repl_tooling/integration/ui.cljs
@@ -14,17 +14,12 @@
             [repl-tooling.repl-client.parsing-test]
             [repl-tooling.repl-client.textual-representation-test]
             [repl-tooling.integration.clojurescript-ui]
-            [repl-tooling.repl-client.evaluation-test]))
+            [repl-tooling.repl-client.evaluation-test]
+            [repl-tooling.features.definition-test]))
 
 (defonce state (r/atom {:host "localhost"
                         :port 2233
- ;                        :code "(do
- ;  (->> (range 100)
- ; (map #(vector % (range %)))
- ; (into {})))
- ; "
                         :code "(do (defrecord Foo [a b]) (->Foo (range 20) 20))"
-                        ; :code "(range 100)"
                         :repls {:eval nil
                                 :aux nil}
                         :commands {}

--- a/test/repl_tooling/repl_client/evaluation_test.cljs
+++ b/test/repl_tooling/repl_client/evaluation_test.cljs
@@ -1,6 +1,5 @@
 (ns repl-tooling.repl-client.evaluation-test
   (:require [clojure.test :refer-macros [testing async is]]
-            [matcher-combinators.test]
             [devcards.core :as cards :include-macros true]
             [check.core :refer-macros [check]]
             [clojure.core.async :as async :include-macros true]


### PR DESCRIPTION
Goto var definition was broken when we ran `load-file` from Chlorine package.