### PR TITLE
UNREPL Blob upgrade for clojure.test

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -89,3 +89,13 @@ Probably, if it is close enought to Clojure. To be "close enough" means that:
 
 ### When jack-in will be implemented?
 I don't intend to implement "jack-in". The thing is, is difficult to cleanup external processes and this could complicate **a lot** the code. Also, there's the problem with environment variables (I had multiple problems when I used editors that used jack-in because env variables were not set, PATH was set to different places and so on), some sandboxing that some editors do, it makes docker difficult do run in this context and **also** makes it necessary to support `lein`, `boot`, `shadow-cljs`, `clj`, `clojure`, and the other specific implementations' CLI, when they exist.
+
+## Bugs / Limitations
+
+### Test output not appearing on the REPL, only on Chlorine
+When you try to run `run-tests` or something that depends on `clojure.test`, sometimes the output will not appear. This is a limitation of `clojure.test` - the output of tests is redirected to `clojure.test/*test-out*`. The first time someone requires `clojure.test`, it'll bind to `*out*`.
+
+So, if you require on the REPL, it'll work all the time. But if you connect to Chlorine before you require it on your REPL, `clojure.test/*test-out*` will be bound to the socket output (that goes to Chlorine). You can re-bind the output using:
+```clojure
+(alter-var-root #'clojure.test/*test-out* (constantly *out*))
+```

--- a/resources/unrepl.clj
+++ b/resources/unrepl.clj
@@ -1,7 +1,7 @@
 (clojure.core/let [nop (clojure.core/constantly nil)
 done (promise)
 e (clojure.core/atom eval)]
-(-> (create-ns 'unrepl.repl$XkQisH7kdleWD1h1jn$ei_rxBPk)
+(-> (create-ns 'unrepl.repl$FH6pTF3H3K_Wy8zYdKnmCK3IUZU)
 (intern '-init-done)
 (alter-var-root
 (fn [v]
@@ -456,9 +456,10 @@ bindings (select-keys (get-thread-bindings) [#'*print-length* #'*print-level* #'
 unrepl/*string-length* Integer/MAX_VALUE]
 (edn-str x)))
 (ns
-unrepl.repl$XkQisH7kdleWD1h1jn$ei_rxBPk
+unrepl.repl$FH6pTF3H3K_Wy8zYdKnmCK3IUZU
 (:require
 [clojure.main :as m]
+[clojure.test :as t]
 [unrepl.core :as unrepl]
 [unrepl.printer$q0kQC1b9AWklEvoDzW2VNG7ZlCg :as p]
 [clojure.edn :as edn]
@@ -820,6 +821,7 @@ slcl (classloader cl
 (swap! session-state assoc :class-loader slcl)
 (swap! sessions assoc session-id session-state)
 (binding [*out* (scheduled-writer :out unrepl/non-eliding-write)
+t/*test-out* (scheduled-writer :out unrepl/non-eliding-write)
 *err* (tagging-writer :err unrepl/non-eliding-write)
 *in* in
 *file* (-> in :coords :file)
@@ -876,5 +878,5 @@ interrupted? #(.peek actions-queue)]
 ~expr))
 <<<FIN
 (clojure.core/ns user)
-(unrepl.repl$XkQisH7kdleWD1h1jn$ei_rxBPk/start (clojure.edn/read {:default tagged-literal} *in*))
+(unrepl.repl$FH6pTF3H3K_Wy8zYdKnmCK3IUZU/start (clojure.edn/read {:default tagged-literal} *in*))
 {}

--- a/src/repl_tooling/repl_client/clojure.cljs
+++ b/src/repl_tooling/repl_client/clojure.cljs
@@ -149,12 +149,6 @@
       :nothing-really)))
 
 (defn- treat-hello! [hello state]
-  (add-to-eval-queue! state
-                      {:cmd "(clojure.core/require '[clojure.test])"
-                       :ignore-result? true})
-  (add-to-eval-queue! state
-                      {:cmd "(clojure.core/alter-var-root #'clojure.test/*test-out* (clojure.core/constantly *out*))"
-                       :ignore-result? true})
   (let [[_ res] (reader/read-string {:readers decoders} hello)]
     (swap! state assoc
            :session (:session res)


### PR DESCRIPTION
Making the redirect of `clojure.test/*test-out*` for UNREPL.

This will do the right redirect, on every connection of the Socket REPL.