### PR TITLE
The new renderer tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.5.3
+- Adding custom tag `:div/clj` to render ANSI char codes
+
 ## 0.5.2
 - Clickable stacktraces for Clojerl
 - Better printer for Clojerl and nREPL

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject repl-tooling "0.5.2"
+(defproject repl-tooling "0.5.3"
   :dependencies [[org.clojure/core.async "0.4.490"]
                  [com.cognitect/transit-cljs "0.8.264"]
                  [reagent "0.10.0"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                  [funcool/promesa "4.0.2"]
                  [rewrite-cljs "0.4.4"]
                  [paprika "0.1.3"]
-                 [borkdude/sci "0.1.1-alpha.6"]
+                 [borkdude/sci "0.1.1-alpha.7"]
                  [org.pinkgorilla/gorilla-renderable-ui "0.1.33"]]
 
   :source-paths ["src"])

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                  [funcool/promesa "4.0.2"]
                  [rewrite-cljs "0.4.4"]
                  [paprika "0.1.3"]
-                 [borkdude/sci "0.0.13-alpha.17"]
+                 [borkdude/sci "0.1.1-alpha.6"]
                  [org.pinkgorilla/gorilla-renderable-ui "0.1.33"]]
 
   :source-paths ["src"])

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,7 +7,7 @@
                 [com.cognitect/transit-cljs "0.8.264"]
                 [funcool/promesa "4.0.2"]
                 [paprika "0.1.3-SNAPSHOT"]
-                [borkdude/sci "0.1.1-alpha.6"]
+                [borkdude/sci "0.1.1-alpha.7"]
                 [compliment "0.4.0-SNAPSHOT"]
                 [rewrite-cljs "0.4.4"]
                 [reagent "0.10.0"]

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,7 +7,7 @@
                 [com.cognitect/transit-cljs "0.8.264"]
                 [funcool/promesa "4.0.2"]
                 [paprika "0.1.3-SNAPSHOT"]
-                [borkdude/sci "0.0.13-alpha.17"]
+                [borkdude/sci "0.1.1-alpha.6"]
                 [compliment "0.4.0-SNAPSHOT"]
                 [rewrite-cljs "0.4.4"]
                 [reagent "0.10.0"]

--- a/src/repl_tooling/editor_helpers.cljs
+++ b/src/repl_tooling/editor_helpers.cljs
@@ -87,8 +87,6 @@
                     pr-str)]
      {:error error :as-text error})))
 
-(defrecord Patchable [id value])
-
 (defn as-obj [data]
   (let [params (last data)
         [browseable pr-str-obj obj-id] data]
@@ -111,7 +109,6 @@
                                 'unrepl/pattern re-pattern
                                 'repl-tooling/literal-render #(LiteralRender. %)
                                 'repl-tooling/interactive #(Interactive. %)
-                                'repl-tooling/patchable #(->Patchable (first %) (second %))
                                 'clojure/var #(->> % (str "#'") symbol)
                                 'error parse-error
                                 'unrepl/object as-obj}

--- a/src/repl_tooling/editor_helpers.cljs
+++ b/src/repl_tooling/editor_helpers.cljs
@@ -87,6 +87,8 @@
                     pr-str)]
      {:error error :as-text error})))
 
+(defrecord Patchable [id value])
+
 (defn as-obj [data]
   (let [params (last data)
         [browseable pr-str-obj obj-id] data]
@@ -109,6 +111,7 @@
                                 'unrepl/pattern re-pattern
                                 'repl-tooling/literal-render #(LiteralRender. %)
                                 'repl-tooling/interactive #(Interactive. %)
+                                'repl-tooling/patchable #(->Patchable (first %) (second %))
                                 'clojure/var #(->> % (str "#'") symbol)
                                 'error parse-error
                                 'unrepl/object as-obj}

--- a/src/repl_tooling/editor_integration/configs.cljs
+++ b/src/repl_tooling/editor_integration/configs.cljs
@@ -6,14 +6,15 @@
             [clojure.string :as str]
             [repl-tooling.editor-integration.commands :as cmds]
             [repl-tooling.editor-helpers :as helpers]
-            [sci.impl.namespaces :as sci-ns]
             [repl-tooling.ui.pinkie :as pinkie]
             [pinkgorilla.ui.jsrender :as jsrender]
             [reagent.core :as r]
             [reagent.dom :as rdom]
+            [repl-tooling.editor-integration.interpreter :as int]
             ["path" :refer [dirname join]]
             ["fs" :refer [watch readFile existsSync]]
-            ["ansi_up" :default Ansi]))
+            ["ansi_up" :default Ansi]
+            [repl-tooling.editor-integration.renderer :as render]))
 
 (defn- read-config-file [config-file]
   (let [p (p/deferred)]
@@ -22,164 +23,6 @@
 
 (defn- name-for [k]
   (-> k name str/capitalize (str/replace #"-" " ")))
-
-(def ^:private promised-let
-  ^:sci/macro
-  (fn [_&form _&env bindings & body]
-    (let [binds (->> bindings (partition-all 2 2) reverse)]
-      (loop [body (cons 'do body)
-             [[var elem] & rest] binds]
-        (if (nil? var)
-          body
-          (recur
-            (list 'then (list 'promise elem) (list 'fn [var] body))
-            rest))))))
-
-(defn- find-repl [state]
-  (p/let [data (cmds/run-callback! state :editor-data)]
-    (cmds/run-feature! state :repl-for (:filename data) true)))
-
-(defn- editor-ns [repl state]
-  (let [repl (delay (or repl (find-repl state)))]
-    {'run-callback (partial cmds/run-callback! state)
-     'run-feature (fn [cmd & args]
-                    (p/let [curr-repl @repl]
-                      (if (= cmd :go-to-var-definition)
-                        (cmds/run-feature! state
-                                           :go-to-var-definition
-                                           (assoc (first args)
-                                                  :repl curr-repl))
-                        (apply cmds/run-feature! state cmd args))))
-     'get-top-block #(cmds/run-feature! state :get-code :top-block)
-     'get-block #(cmds/run-feature! state :get-code :block)
-     'get-var #(cmds/run-feature! state :get-code :var)
-     'get-selection #(cmds/run-feature! state :get-code :selection)
-     'get-namespace #(p/let [res (cmds/run-feature! state :get-code :ns)]
-                       (update res :text str))
-     'eval-and-render #(cmds/run-feature! state :evaluate-and-render %)
-     'eval-interactive #(cmds/run-feature! state :evaluate-and-render
-                                           (update % :pass assoc
-                                                   :interactive true
-                                                   :aux true))
-     'eval (partial cmds/run-feature! state :eval)}))
-
-(defn- norm-reagent-fn [fun]
-  (fn [ & args]
-    (let [empty (js/Object.)
-          state (r/atom empty)
-          render (fn [ state & args]
-                   (if (= empty @state)
-                     (do
-                       (p/let [res (apply fun args)]
-                         (reset! state res))
-                       [:div.repl-tooling.icon.loading])
-                     @state))]
-      (apply vector render state args))))
-
-(defn- norm-pinkie-fn [fun]
-  (fn [ & args]
-    [jsrender/render-js
-     {:f (fn [dom args]
-           (let [div (.createElement js/document "div")
-                 upd (fn [elem]
-                       (try (.removeChild dom div) (catch :default _))
-                       (.appendChild dom elem))
-                 elem (apply fun (js->clj args))]
-             (.. div -classList (add "repl-tooling" "icon" "loading"))
-             (.appendChild dom div)
-             (if (instance? js/Promise elem)
-               (.then elem upd)
-               (upd elem))))
-      :data args}]))
-
-(defn- render-ns [editor-state]
-  {'js-require #(-> @editor-state
-                    :editor/callbacks
-                    :config-file-path
-                    dirname
-                    (join %)
-                    js/require)
-   'create-tag #(.createElement js/document %)
-   'set-text #(aset %1 "innerText" %2)
-   'set-html #(aset %1 "innerHTML" %2)
-   'add-class (fn [^js e & args]
-                (doseq [a args]
-                  (.. e -classList (add a))))
-   'set-attr (fn [^js e attr value]
-              (.setAttribute e attr value))
-   'register-reagent #(if (and (keyword? %1) (namespace %1) (fn? %2))
-                        (pinkie/register-tag %1 (norm-reagent-fn %2))
-                        (cmds/run-callback!
-                         editor-state
-                         :notify
-                         {:type :error
-                          :title "Invalid params"
-                          :text (str "First argument needs to be a namespaced keyword, "
-                                     "and second argument needs to be a reagent fn")}))
-   'register-tag #(if (and (keyword? %1) (namespace %1) (fn? %2))
-                    (pinkie/register-tag %1 (norm-pinkie-fn %2))
-                    (cmds/run-callback!
-                     editor-state
-                     :notify
-                     {:type :error
-                      :title "Invalid params"
-                      :text (str "First argument needs to be a namespaced keyword, "
-                                 "and second argument needs to be a function that "
-                                 "returns a HTML tag")}))})
-
-(defn- prepare-nses [repl editor-state]
-  (-> sci-ns/namespaces
-      (set/rename-keys '{clojure.string str
-                         clojure.set set
-                         clojure.walk walk
-                         clojure.template template
-                         clojure.repl repl
-                         clojure.edn edn})
-      (assoc 'r {'atom r/atom
-                 'render rdom/render
-                 'adapt-react-class r/adapt-react-class
-                 'as-element r/as-element
-                 'create-class r/create-class
-                 'create-element r/create-element
-                 'current-component r/current-component
-                 'cursor r/cursor
-                 'is-client r/is-client
-                 'reactify-component r/reactify-component
-                 'wrap r/wrap})
-      (assoc 'render (render-ns editor-state))
-      (assoc 'editor (editor-ns repl editor-state))))
-
-(def ^:private promised-bindings {'promise #(.resolve js/Promise %)
-                                  'then #(.then ^js %1 %2)
-                                  'catch #(.catch ^js %1 %2)
-                                  'p/let promised-let})
-
-(defn default-bindings [editor-state]
-  (assoc promised-bindings
-         'println (fn [& args]
-                    (cmds/run-callback! editor-state :on-stdout
-                                        (str (str/join " " args) "\n")))
-         'print (fn [& args]
-                   (cmds/run-callback! editor-state :on-stdout
-                                       (str/join " " args)))
-         'prn (fn [& args]
-                (->> args (map pr-str)
-                     (str/join " ")
-                     (#(str % "\n"))
-                     (cmds/run-callback! editor-state :on-stdout)))
-         'log (fn [& args] (apply js/console.log args))
-         'pr (fn [& args]
-                (->> args (map pr-str)
-                     (str/join " ")
-                     (cmds/run-callback! editor-state :on-stdout)))))
-
-(defn evaluate-code [{:keys [code bindings sci-state editor-state repl]
-                      :or {bindings promised-bindings
-                           sci-state (atom {})}}]
-  (sci/eval-string code {:env sci-state
-                         :preset {:termination-safe true}
-                         :namespaces (prepare-nses repl editor-state)
-                         :bindings bindings}))
 
 (defn- catch-errors [fun editor-state]
   (try
@@ -202,11 +45,11 @@
   (when (existsSync config-file)
     (p/let [config (read-config-file config-file)
             sci-state (atom {})
-            bindings (default-bindings editor-state)
-            _ (evaluate-code {:code config
-                              :bindings bindings
-                              :sci-state sci-state
-                              :editor-state editor-state})
+            bindings (int/default-bindings editor-state)
+            _ (int/evaluate-code {:code config
+                                  :bindings bindings
+                                  :sci-state sci-state
+                                  :editor-state editor-state})
             vars (->> (sci/eval-string "(->> *ns* ns-publics keys)" {:env sci-state})
                       (map #(vector % (sci/eval-string (str %) {:env sci-state}))))]
       (->> vars
@@ -277,9 +120,18 @@
                  :dangerouslySetInnerHTML
                  #js {:__html (. ansi ansi_to_html (apply str txts))})]))
 
-(defn prepare-commands [editor-state cmds-from-tooling]
-  (swap! editor-state assoc :editor/commands cmds-from-tooling)
+(defn- clojure-renderer [editor-state edn]
+  (let [fake-res {:result edn :parsed? true :as-text (pr-str edn)}
+        parsed-ratom (render/parse-result fake-res nil editor-state)]
+    [render/view-for-result parsed-ratom]))
+
+(defn register-custom-tags! [editor-state]
   (pinkie/register-tag :div/ansi ansi-tag)
+  (pinkie/register-tag :div/clj #(clojure-renderer editor-state %)))
+
+(defn prepare-commands [editor-state cmds-from-tooling]
+  (register-custom-tags! editor-state)
+  (swap! editor-state assoc :editor/commands cmds-from-tooling)
   (p/let [config-file (-> @editor-state :editor/callbacks :config-file-path)]
     (watch-config editor-state cmds-from-tooling config-file)
     (reg-commands editor-state cmds-from-tooling config-file)))

--- a/src/repl_tooling/editor_integration/interpreter.cljs
+++ b/src/repl_tooling/editor_integration/interpreter.cljs
@@ -1,0 +1,183 @@
+(ns repl-tooling.editor-integration.interpreter
+  (:require [sci.core :as sci]
+            [clojure.set :as set]
+            [promesa.core :as p]
+            [paprika.collection :as coll]
+            [clojure.string :as str]
+            [repl-tooling.editor-integration.commands :as cmds]
+            [repl-tooling.editor-helpers :as helpers]
+            [sci.impl.namespaces :as sci-ns]
+            [repl-tooling.ui.pinkie :as pinkie]
+            [pinkgorilla.ui.jsrender :as jsrender]
+            [reagent.core :as r]
+            [reagent.dom :as rdom]
+            ["path" :refer [dirname join]]
+            ["fs" :refer [watch readFile existsSync]]
+            ["ansi_up" :default Ansi]))
+            ; [repl-tooling.editor-integration.renderer :as renderer]))
+
+(defn- read-config-file [config-file]
+  (let [p (p/deferred)]
+    (readFile config-file #(p/resolve! p (str %2)))
+    p))
+
+(defn- name-for [k]
+  (-> k name str/capitalize (str/replace #"-" " ")))
+
+(def ^:private promised-let
+  ^:sci/macro
+  (fn [_&form _&env bindings & body]
+    (let [binds (->> bindings (partition-all 2 2) reverse)]
+      (loop [body (cons 'do body)
+             [[var elem] & rest] binds]
+        (if (nil? var)
+          body
+          (recur
+            (list 'then (list 'promise elem) (list 'fn [var] body))
+            rest))))))
+
+(defn- find-repl [state]
+  (p/let [data (cmds/run-callback! state :editor-data)]
+    (cmds/run-feature! state :repl-for (:filename data) true)))
+
+(defn- editor-ns [repl state]
+  (let [repl (delay (or repl (find-repl state)))]
+    {'run-callback (partial cmds/run-callback! state)
+     'run-feature (fn [cmd & args]
+                    (p/let [curr-repl @repl]
+                      (if (= cmd :go-to-var-definition)
+                        (cmds/run-feature! state
+                                           :go-to-var-definition
+                                           (assoc (first args)
+                                                  :repl curr-repl))
+                        (apply cmds/run-feature! state cmd args))))
+     'get-top-block #(cmds/run-feature! state :get-code :top-block)
+     'get-block #(cmds/run-feature! state :get-code :block)
+     'get-var #(cmds/run-feature! state :get-code :var)
+     'get-selection #(cmds/run-feature! state :get-code :selection)
+     'get-namespace #(p/let [res (cmds/run-feature! state :get-code :ns)]
+                       (update res :text str))
+     'eval-and-render #(cmds/run-feature! state :evaluate-and-render %)
+     'eval-interactive #(cmds/run-feature! state :evaluate-and-render
+                                           (update % :pass assoc
+                                                   :interactive true
+                                                   :aux true))
+     'eval (partial cmds/run-feature! state :eval)}))
+
+(defn- norm-reagent-fn [fun]
+  (fn [ & args]
+    (let [empty (js/Object.)
+          state (r/atom empty)
+          render (fn [ state & args]
+                   (if (= empty @state)
+                     (do
+                       (p/let [res (apply fun args)]
+                         (reset! state res))
+                       [:div.repl-tooling.icon.loading])
+                     @state))]
+      (apply vector render state args))))
+
+(defn- norm-pinkie-fn [fun]
+  (fn [ & args]
+    [jsrender/render-js
+     {:f (fn [dom args]
+           (let [div (.createElement js/document "div")
+                 upd (fn [elem]
+                       (try (.removeChild dom div) (catch :default _))
+                       (.appendChild dom elem))
+                 elem (apply fun (js->clj args))]
+             (.. div -classList (add "repl-tooling" "icon" "loading"))
+             (.appendChild dom div)
+             (if (instance? js/Promise elem)
+               (.then elem upd)
+               (upd elem))))
+      :data args}]))
+
+(defn- render-ns [editor-state]
+  {'js-require #(-> @editor-state
+                    :editor/callbacks
+                    :config-file-path
+                    dirname
+                    (join %)
+                    js/require)
+   'create-tag #(.createElement js/document %)
+   'set-text #(aset %1 "innerText" %2)
+   'set-html #(aset %1 "innerHTML" %2)
+   'add-class (fn [^js e & args]
+                (doseq [a args]
+                  (.. e -classList (add a))))
+   'set-attr (fn [^js e attr value]
+              (.setAttribute e attr value))
+   'register-reagent #(if (and (keyword? %1) (namespace %1) (fn? %2))
+                        (pinkie/register-tag %1 (norm-reagent-fn %2))
+                        (cmds/run-callback!
+                         editor-state
+                         :notify
+                         {:type :error
+                          :title "Invalid params"
+                          :text (str "First argument needs to be a namespaced keyword, "
+                                     "and second argument needs to be a reagent fn")}))
+   'register-tag #(if (and (keyword? %1) (namespace %1) (fn? %2))
+                    (pinkie/register-tag %1 (norm-pinkie-fn %2))
+                    (cmds/run-callback!
+                     editor-state
+                     :notify
+                     {:type :error
+                      :title "Invalid params"
+                      :text (str "First argument needs to be a namespaced keyword, "
+                                 "and second argument needs to be a function that "
+                                 "returns a HTML tag")}))})
+
+(defn- prepare-nses [repl editor-state]
+  (-> sci-ns/namespaces
+      (set/rename-keys '{clojure.string str
+                         clojure.set set
+                         clojure.walk walk
+                         clojure.template template
+                         clojure.repl repl
+                         clojure.edn edn})
+      (assoc 'r {'atom r/atom
+                 'render rdom/render
+                 'adapt-react-class r/adapt-react-class
+                 'as-element r/as-element
+                 'create-class r/create-class
+                 'create-element r/create-element
+                 'current-component r/current-component
+                 'cursor r/cursor
+                 'is-client r/is-client
+                 'reactify-component r/reactify-component
+                 'wrap r/wrap})
+      (assoc 'render (render-ns editor-state))
+      (assoc 'editor (editor-ns repl editor-state))))
+
+(def ^:private promised-bindings {'promise #(.resolve js/Promise %)
+                                  'then #(.then ^js %1 %2)
+                                  'catch #(.catch ^js %1 %2)
+                                  'p/let promised-let})
+
+(defn default-bindings [editor-state]
+  (assoc promised-bindings
+         'println (fn [& args]
+                    (cmds/run-callback! editor-state :on-stdout
+                                        (str (str/join " " args) "\n")))
+         'print (fn [& args]
+                   (cmds/run-callback! editor-state :on-stdout
+                                       (str/join " " args)))
+         'prn (fn [& args]
+                (->> args (map pr-str)
+                     (str/join " ")
+                     (#(str % "\n"))
+                     (cmds/run-callback! editor-state :on-stdout)))
+         'log (fn [& args] (apply js/console.log args))
+         'pr (fn [& args]
+                (->> args (map pr-str)
+                     (str/join " ")
+                     (cmds/run-callback! editor-state :on-stdout)))))
+
+(defn evaluate-code [{:keys [code bindings sci-state editor-state repl]
+                      :or {bindings promised-bindings
+                           sci-state (atom {})}}]
+  (sci/eval-string code {:env sci-state
+                         :preset {:termination-safe true}
+                         :namespaces (prepare-nses repl editor-state)
+                         :bindings bindings}))

--- a/src/repl_tooling/editor_integration/interpreter.cljs
+++ b/src/repl_tooling/editor_integration/interpreter.cljs
@@ -180,7 +180,9 @@
 
 (defn- readers-for [editor-state]
   {'repl-tooling.editor-helpers.Error helpers/map->Error
-   'repl-tooling.editor-helpers.Browseable helpers/map->Browseable})
+   'repl-tooling.editor-helpers.Browseable helpers/map->Browseable
+   'repl-tooling.editor-helpers.Patchable helpers/map->Patchable
+   'repl-tooling.editor-helpers.IncompleteObj helpers/map->IncompleteObj})
 
 (defn evaluate-code [{:keys [code bindings sci-state editor-state repl]
                       :or {sci-state (atom {})}}]

--- a/src/repl_tooling/editor_integration/renderer.cljs
+++ b/src/repl_tooling/editor_integration/renderer.cljs
@@ -485,10 +485,6 @@
   (as-renderable [obj repl editor-state]
     (r/atom (->Leaf obj editor-state)))
 
-  helpers/Patchable
-  (as-renderable [{:keys [id value]} repl editor-state]
-    (r/atom (->Patchable id (proto/as-renderable value repl editor-state))))
-
   default
   (as-renderable [obj repl editor-state]
     (r/atom

--- a/src/repl_tooling/editor_integration/renderer.cljs
+++ b/src/repl_tooling/editor_integration/renderer.cljs
@@ -424,7 +424,7 @@
       [:div {:class "exception row"}
        [:div {:class "description"}
         [:span {:class "ex-kind"} (str type)] ": " [proto/as-html @message message root?]]
-       (when add-data
+       (when (and add-data root?)
          [:div {:class "children additional"}
           [proto/as-html @add-data add-data root?]])
        (when root?

--- a/src/repl_tooling/editor_integration/renderer.cljs
+++ b/src/repl_tooling/editor_integration/renderer.cljs
@@ -485,6 +485,10 @@
   (as-renderable [obj repl editor-state]
     (r/atom (->Leaf obj editor-state)))
 
+  helpers/Patchable
+  (as-renderable [{:keys [id value]} repl editor-state]
+    (r/atom (->Patchable id (proto/as-renderable value repl editor-state))))
+
   default
   (as-renderable [obj repl editor-state]
     (r/atom

--- a/src/repl_tooling/editor_integration/renderer/interactive.cljs
+++ b/src/repl_tooling/editor_integration/renderer/interactive.cljs
@@ -5,8 +5,7 @@
             [repl-tooling.eval :as eval]
             [repl-tooling.editor-integration.renderer.protocols :as proto]
             [repl-tooling.ui.pinkie :as pinkie]
-            [sci.core :as sci]
-            [repl-tooling.editor-integration.configs :as configs]))
+            [repl-tooling.editor-integration.interpreter :as int]))
 
 (defn- edn? [obj]
   (or (number? obj)
@@ -66,7 +65,7 @@
                  (-> {:code code
                       :bindings (bindings-for state fns repl)
                       :editor-state editor-state}
-                     configs/evaluate-code
+                     int/evaluate-code
                      pinkie/tag-inject
                      treat-error)
                  (catch :default e

--- a/src/repl_tooling/editor_integration/renderer/interactive.cljs
+++ b/src/repl_tooling/editor_integration/renderer/interactive.cljs
@@ -63,7 +63,8 @@
         html (fn [state]
                (try
                  (-> {:code code
-                      :bindings (bindings-for state fns repl)
+                      :bindings (merge (bindings-for state fns repl)
+                                       (int/default-bindings editor-state))
                       :editor-state editor-state}
                      int/evaluate-code
                      pinkie/tag-inject

--- a/src/repl_tooling/editor_integration/renderer/interactive.cljs
+++ b/src/repl_tooling/editor_integration/renderer/interactive.cljs
@@ -63,8 +63,9 @@
         html (fn [state]
                (try
                  (-> {:code code
-                      :bindings (merge (bindings-for state fns repl)
-                                       (int/default-bindings editor-state))
+                      :bindings (assoc (bindings-for state fns repl)
+                                       'log (fn [& args] (apply js/console.log args)))
+
                       :editor-state editor-state}
                      int/evaluate-code
                      pinkie/tag-inject

--- a/src/repl_tooling/editor_integration/schemas.cljs
+++ b/src/repl_tooling/editor_integration/schemas.cljs
@@ -131,5 +131,4 @@
                            (s/optional-key :cljs/repl-env) s/Any
                            (s/optional-key :cljs/autocomplete-kind) s/Any
                            (s/optional-key :clj/autocomplete-kind) s/Any}
-
                           :editor/commands Commands}))

--- a/test/repl_tooling/editor_integration/configs_test.cljs
+++ b/test/repl_tooling/editor_integration/configs_test.cljs
@@ -6,6 +6,7 @@
             [repl-tooling.integration.fake-editor :as editor]
             [clojure.core.async :as async]
             [check.async :refer [async-test await!]]
+            [repl-tooling.editor-integration.interpreter :as int]
             ["fs" :refer [writeFileSync]]))
 
 (cards/defcard-rg fake-editor
@@ -21,17 +22,17 @@
 (cards/deftest config-eval
   (async-test "evaluating code"
     (testing "evaluates simple code"
-      (check (configs/evaluate-code {:code "(+ 1 2)" :editor-state (atom {})}) => 3))
+      (check (int/evaluate-code {:code "(+ 1 2)" :editor-state (atom {})}) => 3))
 
     (testing "resolves promises with p/let"
-      (-> (configs/evaluate-code {:code "(p/let [a (promise 1) b (promise 2)] (+ a b))"
-                                  :editor-state (atom {})})
+      (-> (int/evaluate-code {:code "(p/let [a (promise 1) b (promise 2)] (+ a b))"
+                              :editor-state (atom {})})
           await!
           (check => 3)))
 
     (testing "resolves mixed promises / non-promises"
-      (-> (configs/evaluate-code {:code "(p/let [a (promise 1) b 2] (+ a b))"
-                                  :editor-state (atom {})})
+      (-> (int/evaluate-code {:code "(p/let [a (promise 1) b 2] (+ a b))"
+                              :editor-state (atom {})})
           await!
           (check => 3)))))
 

--- a/test/repl_tooling/editor_integration/renderer/interactive_test.cljs
+++ b/test/repl_tooling/editor_integration/renderer/interactive_test.cljs
@@ -9,7 +9,8 @@
             [repl-tooling.integration.ui-macros :as m]
             [repl-tooling.eval-helpers :as e]
             [clojure.core.async :as async]
-            [devcards.core :as cards]))
+            [devcards.core :as cards]
+            [repl-tooling.editor-integration.configs :as configs]))
 
 (m/card-for-renderer!)
 (defn render [interactive-obj repl]
@@ -64,4 +65,9 @@
               repl)
       (check (wait-for-change m/text-on-result) => {:text "20"})
       (m/click-on "20")
-      (check (wait-for-change m/text-on-result) => {:text "21"}))))
+      (check (wait-for-change m/text-on-result) => {:text "21"}))
+
+    (testing "renders tooling's EDN renderer"
+      (configs/register-custom-tags! {})
+      (render '{:html [:div/clj '(+ 1 2 3 4)]} repl)
+      (check (wait-for-change m/text-on-result) => {:text "( + 1 2 3 4 )"}))))


### PR DESCRIPTION
Registering `:div/clj` that will delegate rendering to Repl-Tooling's internal renderer.

This way, it's possible to render exceptions like:

`[:div/clj (ex-info "Some error" {})]`