### PR TITLE
Fix CLJS REPL for pathom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.5
 - Fixed nREPL code disconnecting when you send accents
 - Fixed some undetectable var definitions
+- Fixed ClojureScript REPL detection on `.cljs` when `:prefer-cljs` option is selected
 
 ## 0.5.3
 - Bugfixes on some edge cases

--- a/src/repl_tooling/commands_to_repl/pathom.cljs
+++ b/src/repl_tooling/commands_to_repl/pathom.cljs
@@ -148,12 +148,10 @@
   {::connect/input #{:var/fqn :cljs/required? :repl/aux :repl/clj}
    ::connect/output [:var/meta]}
 
-  ; (prn :REPL aux)
   (p/let [keys (-> ast :params :keys)
           res (-> aux
                   (eval/eval (str "(clojure.core/meta #'" fqn ")"))
                   (p/catch (constantly nil)))
-          ; _ (prn :RES res)
           res (if (and required? (-> res :result nil?))
                 (eval/eval clj (str "(clojure.core/meta #'" fqn ")"))
                 res)]

--- a/test/repl_tooling/editor_integration/pathom_test.cljs
+++ b/test/repl_tooling/editor_integration/pathom_test.cljs
@@ -80,6 +80,12 @@
       (swap! fake/state assoc :filename "somefile.cljs")
       (check (pathom/eql {:editor-state (:editor-state @fake/state)}
                          [:repl/eval :repl/aux :repl/clj])
+             => cljs-repls)
+
+      (swap! config assoc :eval-mode :prefer-cljs)
+      (swap! fake/state assoc :filename "somefile.cljs")
+      (check (pathom/eql {:editor-state (:editor-state @fake/state)}
+                         [:repl/eval :repl/aux :repl/clj])
              => cljs-repls))
 
     (testing "getting current namespace when there's a NS form"


### PR DESCRIPTION
- Fixed ClojureScript REPL detection on `.cljs` when `:prefer-cljs` option is selected
