### PR TITLE
Fix shadow over wss://

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.6.0
+- Shadow-CLJS now can connect when the remote API is running over SSL
 - Migrated most of Pathom code to a new project called Duck-REPLed
 - Disabled clj-kondo statistics for now
 - Fixed stacktraces in Clojerl

--- a/src/repl_tooling/integrations/connection.cljs
+++ b/src/repl_tooling/integrations/connection.cljs
@@ -54,9 +54,12 @@ runs the command to change it to CLJS, and returns an evaluator for CLJS."
     :or {identifier :cljs-eval}}]
   (let [host "localhost"
         dir (->> directories
-                 (filter #(existsSync (join % ".shadow-cljs" "http.port")))
+                 (filter #(existsSync (join % ".shadow-cljs" "server.token")))
                  first)
-        port (-> (join dir ".shadow-cljs" "http.port") readFileSync str js/parseInt)
+        port-file (if (existsSync (join dir ".shadow-cljs" "https-port.port"))
+                    "https-port.port"
+                    "http.port")
+        port (-> (join dir ".shadow-cljs" port-file) readFileSync str js/parseInt)
         token (-> (join dir ".shadow-cljs" "server.token") readFileSync str)
         on-output (fn [res]
                     (cond
@@ -84,4 +87,5 @@ runs the command to change it to CLJS, and returns an evaluator for CLJS."
                          :host host
                          :port port
                          :token token
-                         :on-output on-output})))
+                         :on-output on-output
+                         :ssl? (= port-file "https-port.port")})))


### PR DESCRIPTION
- Shadow-CLJS now can connect when the remote API is running over SSL
